### PR TITLE
.NET Core 2.0 and multi targeting references

### DIFF
--- a/Automaty.sln
+++ b/Automaty.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26430.14
+VisualStudioVersion = 15.0.26730.12
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Automaty.Core", "src\Automaty.Core\Automaty.Core.csproj", "{220952CC-7296-4C6F-8033-AAFF13630D46}"
 EndProject
@@ -26,6 +26,14 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{8B9BC527-C055-4293-A167-F66187643822}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Automaty.Samples.Test", "test\Automaty.Samples.Test\Automaty.Samples.Test.csproj", "{EA26EABC-DE86-45EE-94E7-7AF939D9F00A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Automaty.Samples.HelloWorld.ProjectReference", "samples\Automaty.Samples.HelloWorld.ProjectReference\Automaty.Samples.HelloWorld.ProjectReference.csproj", "{C34626FE-6FA1-4233-929A-4AFFEBEFD668}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Automaty.Samples.HelloWorld.ProjectReference.ClassLibrary", "samples\Automaty.Samples.HelloWorld.ProjectReference.ClassLibrary\Automaty.Samples.HelloWorld.ProjectReference.ClassLibrary.csproj", "{69EFD5DC-578D-4569-A04B-54693D17FACA}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Automaty.Samples.HelloWorld.ProjectReferenceMulti", "samples\Automaty.Samples.HelloWorld.ProjectReferenceMulti\Automaty.Samples.HelloWorld.ProjectReferenceMulti.csproj", "{6D95ABBB-35C5-48B7-B26F-8287ED4508FB}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Automaty.Samples.HelloWorld.ProjectReferenceMulti.ClassLibrary", "samples\Automaty.Samples.HelloWorld.ProjectReferenceMulti.ClassLibrary\Automaty.Samples.HelloWorld.ProjectReferenceMulti.ClassLibrary.csproj", "{D9540AEE-5127-4105-A869-61C7FE087154}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -69,6 +77,22 @@ Global
 		{EA26EABC-DE86-45EE-94E7-7AF939D9F00A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EA26EABC-DE86-45EE-94E7-7AF939D9F00A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EA26EABC-DE86-45EE-94E7-7AF939D9F00A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C34626FE-6FA1-4233-929A-4AFFEBEFD668}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C34626FE-6FA1-4233-929A-4AFFEBEFD668}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C34626FE-6FA1-4233-929A-4AFFEBEFD668}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C34626FE-6FA1-4233-929A-4AFFEBEFD668}.Release|Any CPU.Build.0 = Release|Any CPU
+		{69EFD5DC-578D-4569-A04B-54693D17FACA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{69EFD5DC-578D-4569-A04B-54693D17FACA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{69EFD5DC-578D-4569-A04B-54693D17FACA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{69EFD5DC-578D-4569-A04B-54693D17FACA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6D95ABBB-35C5-48B7-B26F-8287ED4508FB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6D95ABBB-35C5-48B7-B26F-8287ED4508FB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6D95ABBB-35C5-48B7-B26F-8287ED4508FB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6D95ABBB-35C5-48B7-B26F-8287ED4508FB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D9540AEE-5127-4105-A869-61C7FE087154}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D9540AEE-5127-4105-A869-61C7FE087154}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D9540AEE-5127-4105-A869-61C7FE087154}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D9540AEE-5127-4105-A869-61C7FE087154}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -83,5 +107,12 @@ Global
 		{601FABEF-FC41-42FD-95D0-C4E13212C246} = {9D11DE25-2EFE-4C76-8A16-9DC3D5445E6A}
 		{9596E161-F6A4-4A75-AE82-8E45F65499C7} = {9D11DE25-2EFE-4C76-8A16-9DC3D5445E6A}
 		{EA26EABC-DE86-45EE-94E7-7AF939D9F00A} = {8B9BC527-C055-4293-A167-F66187643822}
+		{C34626FE-6FA1-4233-929A-4AFFEBEFD668} = {9D11DE25-2EFE-4C76-8A16-9DC3D5445E6A}
+		{69EFD5DC-578D-4569-A04B-54693D17FACA} = {9D11DE25-2EFE-4C76-8A16-9DC3D5445E6A}
+		{6D95ABBB-35C5-48B7-B26F-8287ED4508FB} = {9D11DE25-2EFE-4C76-8A16-9DC3D5445E6A}
+		{D9540AEE-5127-4105-A869-61C7FE087154} = {9D11DE25-2EFE-4C76-8A16-9DC3D5445E6A}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {66B435B7-92D4-405C-BCAE-30EAE83609FD}
 	EndGlobalSection
 EndGlobal

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,21 @@
+FROM microsoft/dotnet:1.1.2-sdk
+
+# Install .NET Core SDK
+ENV DOTNET_SDK_VERSION 2.0.0
+ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-x64.tar.gz
+ENV DOTNET_SDK_DOWNLOAD_SHA E457F3A5685382F7F24851A2E76EDBE75B575948C8A7F43220F159BA29C329A5008BBE7220C18DFB31EAF0398FC72177B1948B65E19B34ED0D907EFB459CF4B0
+
+RUN curl -SL $DOTNET_SDK_DOWNLOAD_URL --output dotnet.tar.gz \
+    && echo "$DOTNET_SDK_DOWNLOAD_SHA dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+# Trigger the population of the local package cache
+ENV NUGET_XMLDOC_MODE skip
+RUN mkdir warmup \
+    && cd warmup \
+    && dotnet new \
+    && cd .. \
+    && rm -rf warmup \
+&& rm -rf /tmp/NuGetScratch

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,9 @@ version: '2'
 
 services:
   automaty.samples.test:
-    image: microsoft/dotnet:sdk
+    build:
+      context: .
+      dockerfile: Dockerfile
     volumes:
       - .\..:/src
     command:

--- a/samples/Automaty.Samples.HelloWorld.ProjectReference.ClassLibrary/Automaty.Samples.HelloWorld.ProjectReference.ClassLibrary.csproj
+++ b/samples/Automaty.Samples.HelloWorld.ProjectReference.ClassLibrary/Automaty.Samples.HelloWorld.ProjectReference.ClassLibrary.csproj
@@ -1,0 +1,7 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+	</PropertyGroup>
+
+</Project>

--- a/samples/Automaty.Samples.HelloWorld.ProjectReference.ClassLibrary/Class.cs
+++ b/samples/Automaty.Samples.HelloWorld.ProjectReference.ClassLibrary/Class.cs
@@ -1,0 +1,6 @@
+﻿namespace Automaty.Samples.HelloWorld.ProjectReference.ClassLibrary
+{
+	public class Class
+	{
+	}
+}

--- a/samples/Automaty.Samples.HelloWorld.ProjectReference/Automaty.Samples.HelloWorld.ProjectReference.csproj
+++ b/samples/Automaty.Samples.HelloWorld.ProjectReference/Automaty.Samples.HelloWorld.ProjectReference.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Automaty.Common" Version="1.0.0-alpha2" />
+		<DotNetCliToolReference Include="Automaty.DotNetCli" Version="1.0.0-alpha7" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\Automaty.Samples.HelloWorld.ProjectReference.ClassLibrary\Automaty.Samples.HelloWorld.ProjectReference.ClassLibrary.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/samples/Automaty.Samples.HelloWorld.ProjectReference/HelloWorld.cs
+++ b/samples/Automaty.Samples.HelloWorld.ProjectReference/HelloWorld.cs
@@ -1,0 +1,14 @@
+﻿namespace Automaty.Samples.HelloWorld.ProjectReference
+{
+	using Automaty.Common.Execution;
+	using Automaty.Common.Output;
+	using Automaty.Samples.HelloWorld.ProjectReference.ClassLibrary;
+
+	public class HelloWorld : IAutomatyHost
+	{
+		public void Execute(IScriptContext context)
+		{
+			context.Output["helloworld.txt"].WriteLine(typeof(Class).FullName);
+		}
+	}
+}

--- a/samples/Automaty.Samples.HelloWorld.ProjectReferenceMulti.ClassLibrary/Automaty.Samples.HelloWorld.ProjectReferenceMulti.ClassLibrary.csproj
+++ b/samples/Automaty.Samples.HelloWorld.ProjectReferenceMulti.ClassLibrary/Automaty.Samples.HelloWorld.ProjectReferenceMulti.ClassLibrary.csproj
@@ -1,0 +1,8 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netstandard2.0;net46</TargetFrameworks>
+		<TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.0;netcoreapp2.0</TargetFrameworks>
+	</PropertyGroup>
+
+</Project>

--- a/samples/Automaty.Samples.HelloWorld.ProjectReferenceMulti.ClassLibrary/Class.cs
+++ b/samples/Automaty.Samples.HelloWorld.ProjectReferenceMulti.ClassLibrary/Class.cs
@@ -1,0 +1,6 @@
+﻿namespace Automaty.Samples.HelloWorld.ProjectReference.ClassLibrary
+{
+	public class Class
+	{
+	}
+}

--- a/samples/Automaty.Samples.HelloWorld.ProjectReferenceMulti/Automaty.Samples.HelloWorld.ProjectReferenceMulti.csproj
+++ b/samples/Automaty.Samples.HelloWorld.ProjectReferenceMulti/Automaty.Samples.HelloWorld.ProjectReferenceMulti.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Automaty.Common" Version="1.0.0-alpha2" />
+		<DotNetCliToolReference Include="Automaty.DotNetCli" Version="1.0.0-alpha7" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\Automaty.Samples.HelloWorld.ProjectReferenceMulti.ClassLibrary\Automaty.Samples.HelloWorld.ProjectReferenceMulti.ClassLibrary.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/samples/Automaty.Samples.HelloWorld.ProjectReferenceMulti/HelloWorld.cs
+++ b/samples/Automaty.Samples.HelloWorld.ProjectReferenceMulti/HelloWorld.cs
@@ -1,0 +1,14 @@
+﻿namespace Automaty.Samples.HelloWorld.ProjectReference
+{
+	using Automaty.Common.Execution;
+	using Automaty.Common.Output;
+	using Automaty.Samples.HelloWorld.ProjectReference.ClassLibrary;
+
+	public class HelloWorld : IAutomatyHost
+	{
+		public void Execute(IScriptContext context)
+		{
+			context.Output["helloworld.txt"].WriteLine(typeof(Class).FullName);
+		}
+	}
+}

--- a/src/Automaty.Core/Automaty.Core.csproj
+++ b/src/Automaty.Core/Automaty.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
 	<PropertyGroup>
-		<Version>1.0.0-alpha6</Version>
+		<Version>1.0.0-alpha7</Version>
 		<PackageId>Automaty.Core</PackageId>
 		<Description>The core library for Automaty - a .NET Core based code automation tool for .NET Core projects.</Description>
 		<PackageTags>CodeGeneration CodeGen T4</PackageTags>

--- a/src/Automaty.Core/Resolution/PropertyNames.cs
+++ b/src/Automaty.Core/Resolution/PropertyNames.cs
@@ -8,5 +8,6 @@
 		public const string OutputType = nameof(PropertyNames.OutputType);
 		public const string ProjectAssetsFile = nameof(PropertyNames.ProjectAssetsFile);
 		public const string TargetFramework = nameof(PropertyNames.TargetFramework);
+		public const string TargetFrameworks = nameof(PropertyNames.TargetFrameworks);
 	}
 }

--- a/src/Automaty.DotNetCli/Automaty.DotNetCli.csproj
+++ b/src/Automaty.DotNetCli/Automaty.DotNetCli.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>netcoreapp2.0</TargetFramework>
 		<AssemblyName>dotnet-automaty</AssemblyName>
 
-		<Version>1.0.0-alpha6</Version>
+		<Version>1.0.0-alpha7</Version>
 		<PackageType>DotNetCliTool</PackageType>
 		<Description>The command-line interface (CLI) for Automaty - a .NET Core based code automation tool for .NET Core projects.</Description>
 		<PackageId>Automaty.DotNetCli</PackageId>

--- a/src/Automaty.DotNetCli/Automaty.DotNetCli.csproj
+++ b/src/Automaty.DotNetCli/Automaty.DotNetCli.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>netcoreapp1.0</TargetFramework>
+		<TargetFramework>netcoreapp2.0</TargetFramework>
 		<AssemblyName>dotnet-automaty</AssemblyName>
 
 		<Version>1.0.0-alpha6</Version>

--- a/test/Automaty.Samples.Test/HelloWorldProjectReferenceMultiTest.cs
+++ b/test/Automaty.Samples.Test/HelloWorldProjectReferenceMultiTest.cs
@@ -1,0 +1,45 @@
+namespace Automaty.Samples.Test
+{
+	using System;
+	using System.IO;
+	using Automaty.Core;
+	using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+	[TestClass]
+	public class HelloWorldProjectReferenceMultiTest
+	{
+		protected const string ProjectDirectoryPath = "./samples/Automaty.Samples.HelloWorld.ProjectReferenceMulti/";
+
+		protected const string ProjectFilePath = "Automaty.Samples.HelloWorld.ProjectReferenceMulti.csproj";
+
+		protected const string ClassLibraryProjectDirectoryPath = "./samples/Automaty.Samples.HelloWorld.ProjectReferenceMulti.ClassLibrary/";
+
+		protected const string ClassLibraryProjectFilePath = "Automaty.Samples.HelloWorld.ProjectReferenceMulti.ClassLibrary.csproj";
+
+		[TestMethod]
+		public void AutomatyHelloWorldProjectReferenceMultiGenerateFiles()
+		{
+			string sampleProjectDirectoryPath = HelloWorldProjectReferenceMultiTest.ProjectDirectoryPath.ToPlatformSpecificPath();
+			string projectFilePath = HelloWorldProjectReferenceMultiTest.ProjectFilePath;
+
+			string classLibraryProjectDirectoryPath = HelloWorldProjectReferenceMultiTest.ClassLibraryProjectDirectoryPath.ToPlatformSpecificPath();
+			string classLibraryProjectFilePath = HelloWorldProjectReferenceMultiTest.ClassLibraryProjectFilePath;
+
+			string sourceFilePath = "HelloWorld.cs";
+			string generatedFilePath = "helloworld.txt";
+
+			Helper.AssertSampleProjectDirectoryPathExists(sampleProjectDirectoryPath);
+			Helper.AssertGeneratedFileDoesNotExist(sampleProjectDirectoryPath, generatedFilePath);
+
+			Helper.DotNetRestore(classLibraryProjectDirectoryPath, classLibraryProjectFilePath);
+			Helper.DotNetBuild(classLibraryProjectDirectoryPath, classLibraryProjectFilePath);
+
+			Helper.DotNetRestore(sampleProjectDirectoryPath, projectFilePath);
+			Helper.AutomatyRun(sampleProjectDirectoryPath, $"{sourceFilePath} --project {projectFilePath}");
+
+			Helper.AssertGeneratedFileExists(sampleProjectDirectoryPath, generatedFilePath);
+
+			Assert.AreEqual(File.ReadAllText(Path.Combine(sampleProjectDirectoryPath, generatedFilePath)), $"Automaty.Samples.HelloWorld.ProjectReference.ClassLibrary.Class{Environment.NewLine}");
+		}
+	}
+}

--- a/test/Automaty.Samples.Test/HelloWorldProjectReferenceTest.cs
+++ b/test/Automaty.Samples.Test/HelloWorldProjectReferenceTest.cs
@@ -1,0 +1,45 @@
+namespace Automaty.Samples.Test
+{
+	using System;
+	using System.IO;
+	using Automaty.Core;
+	using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+	[TestClass]
+	public class HelloWorldProjectReferenceTest
+	{
+		protected const string ProjectDirectoryPath = "./samples/Automaty.Samples.HelloWorld.ProjectReference/";
+
+		protected const string ProjectFilePath = "Automaty.Samples.HelloWorld.ProjectReference.csproj";
+
+		protected const string ClassLibraryProjectDirectoryPath = "./samples/Automaty.Samples.HelloWorld.ProjectReference.ClassLibrary/";
+
+		protected const string ClassLibraryProjectFilePath = "Automaty.Samples.HelloWorld.ProjectReference.ClassLibrary.csproj";
+
+		[TestMethod]
+		public void AutomatyHelloWorldProjectReferenceGenerateFiles()
+		{
+			string sampleProjectDirectoryPath = HelloWorldProjectReferenceTest.ProjectDirectoryPath.ToPlatformSpecificPath();
+			string projectFilePath = HelloWorldProjectReferenceTest.ProjectFilePath;
+
+			string classLibraryProjectDirectoryPath = HelloWorldProjectReferenceTest.ClassLibraryProjectDirectoryPath.ToPlatformSpecificPath();
+			string classLibraryProjectFilePath = HelloWorldProjectReferenceTest.ClassLibraryProjectFilePath;
+
+			string sourceFilePath = "HelloWorld.cs";
+			string generatedFilePath = "helloworld.txt";
+
+			Helper.AssertSampleProjectDirectoryPathExists(sampleProjectDirectoryPath);
+			Helper.AssertGeneratedFileDoesNotExist(sampleProjectDirectoryPath, generatedFilePath);
+
+			Helper.DotNetRestore(classLibraryProjectDirectoryPath, classLibraryProjectFilePath);
+			Helper.DotNetBuild(classLibraryProjectDirectoryPath, classLibraryProjectFilePath);
+
+			Helper.DotNetRestore(sampleProjectDirectoryPath, projectFilePath);
+			Helper.AutomatyRun(sampleProjectDirectoryPath, $"{sourceFilePath} --project {projectFilePath}");
+
+			Helper.AssertGeneratedFileExists(sampleProjectDirectoryPath, generatedFilePath);
+
+			Assert.AreEqual(File.ReadAllText(Path.Combine(sampleProjectDirectoryPath, generatedFilePath)), $"Automaty.Samples.HelloWorld.ProjectReference.ClassLibrary.Class{Environment.NewLine}");
+		}
+	}
+}


### PR DESCRIPTION
I've upgraded the .NET CLI tool to support .NET Core 2.0 and added support for multi targeting project references. It may be necessary to improve target framework resolution in the future. It should fix the https://github.com/Dresel/Automaty/issues/1 issue.